### PR TITLE
Remove duplicate imagerepositories entry

### DIFF
--- a/renderer.tsx
+++ b/renderer.tsx
@@ -225,12 +225,6 @@ export default class FluxCDExtension extends Renderer.LensExtension {
       },
     },
     {
-      id: 'imagerepositories',
-      components: {
-        Page: () => <FluxCDHelmRepositories extension={this} />,
-      },
-    },
-    {
       id: 'imagepolicies',
       components: {
         Page: () => <FluxCDImagePolicies extension={this} />,


### PR DESCRIPTION
## Description
After installing the extension in OpenLens version 6.1.14, the FluxCD menu entry did not appear even though the extension was set to 'enabled'. The Chrome DevTools console displayed the following error: `Uncaught (in promise) Error: Tried to register multiple injectables for ID "route-imagerepositories-for-extension-lens-extension-fluxcd"`. To resolve this issue, I removed a duplicate entry in the `clusterPages` array.

## Related Issue(s)
None

## Testing
I installed the patched version in OpenLens 6.1.14. The previously encountered error has been resolved, and the FluxCD menu entry is now visible.

## Lens Version
OpenLens: 6.1.14
OpenLens API: 6.1.14
Electron: 19.0.17
Node: 16.14.2
